### PR TITLE
feat: componente InputForm

### DIFF
--- a/src/components/InputForm/index.js
+++ b/src/components/InputForm/index.js
@@ -1,0 +1,5 @@
+import { Input } from './styles';
+
+export const InputForm = ({ type, text, size, name }) => {
+  return <Input size={size} type={type} placeholder={text} name={name} />;
+};

--- a/src/components/InputForm/styles.js
+++ b/src/components/InputForm/styles.js
@@ -1,0 +1,44 @@
+import styled, { css } from 'styled-components';
+
+export const Input = styled.input`
+  border: 1px solid #000000;
+  background: #ebf1e7;
+  border-radius: 8px;
+  border: 1px solid #737871;
+  padding: 12px 16px 14px;
+  color: #737871;
+  font-weight: 300;
+  font-size: ${({ theme }) => theme.typography.h4.fontSize};
+
+  &:focus {
+    background: #ebf1e7;
+    box-shadow: 0 0 0 0;
+    outline: 0;
+  }
+
+  ${({ size }) => css`
+    ${!!size && modifierContainer[size]()}
+  `}
+`;
+
+const modifierContainer = {
+  tiny: () => css`
+    width: 98px;
+    height: 48px;
+  `,
+
+  small: () => css`
+    width: 230px;
+    height: 48px;
+  `,
+
+  medium: () => css`
+    width: 262px;
+    height: 40px;
+  `,
+
+  big: () => css`
+    width: 343px;
+    height: 48px;
+  `,
+};


### PR DESCRIPTION
- Adicionando o componente InputForm, que será usado para digitar o cupom e nos formulários de cadastramento tanto do usuário como do produtor. 
- Recebendo 4 props: 
- text: será usado para adicionar o placeholder;
- size: será usado para alterar o width e height;
- type: será usado para alterar o tipo do input;
- name: será usado para referenciar dados de formulário após o envio de um formulário;